### PR TITLE
common: Move aux camera whitelist prop to vendor

### DIFF
--- a/common/dynamic/property_contexts
+++ b/common/dynamic/property_contexts
@@ -1,3 +1,2 @@
-# Aux camera {black,white}list props readable to everything
+# Aux camera blacklist prop readable to everything
 vendor.camera.aux.packageblacklist     u:object_r:exported_default_prop:s0
-vendor.camera.aux.packagelist          u:object_r:exported_default_prop:s0

--- a/common/vendor/property_contexts
+++ b/common/vendor/property_contexts
@@ -1,0 +1,2 @@
+# Aux camera whitelist prop readable to everything
+vendor.camera.aux.packagelist          u:object_r:exported_default_prop:s0


### PR DESCRIPTION
 * Conflict with pre-Q CAF vendor policy thus prebuilt vendor devices
   fail to boot.

Change-Id: Ie6a6a72b084ef40595dbae3eb591b79b607d0f40