### PR TITLE
sepolciy: wifi-ext: Guard atoll from wifi-ext/legacy sepolicy

### DIFF
--- a/wifi-ext/sepolicy.mk
+++ b/wifi-ext/sepolicy.mk
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ifeq (,$(filter sm6150 msmnile trinket, $(TARGET_BOARD_PLATFORM)))
+ifeq (,$(filter sm6150 atoll msmnile trinket, $(TARGET_BOARD_PLATFORM)))
 BOARD_SEPOLICY_DIRS += \
 	device/custom/sepolicy/wifi-ext/qcom/legacy
 endif


### PR DESCRIPTION
Signed-off-by: Henrique Pereira <hlcpereira@pixelexperience.org>
Change-Id: I4496517258fa92d20ed3b1d9195fe26f095c754d